### PR TITLE
IOS AvAudioSession Configuration Update New

### DIFF
--- a/ios/Classes/Music.swift
+++ b/ios/Classes/Music.swift
@@ -114,6 +114,7 @@ public class Player : NSObject, AVAudioPlayerDelegate {
     
     var _loopSingleAudio = false
     var isLiveStream: Bool = false
+    var isDefaultAudioConfigurationEnabled: Bool = true
     
     init(channel: FlutterMethodChannel, registrar: FlutterPluginRegistrar) {
         self.channel = channel
@@ -178,11 +179,11 @@ public class Player : NSObject, AVAudioPlayerDelegate {
     #if os(iOS)
     func getAudioCategory(respectSilentMode: Bool, showNotification: Bool) ->  AVAudioSession.Category {
         if(showNotification) {
-            return AVAudioSession.Category.multiRoute
+            return AVAudioSession.Category.playback
         } else if(respectSilentMode) {
             return AVAudioSession.Category.soloAmbient
         } else {
-            return AVAudioSession.Category.multiRoute
+            return AVAudioSession.Category.playback
         }
     }
     #endif
@@ -275,19 +276,23 @@ public class Player : NSObject, AVAudioPlayerDelegate {
         
         //https://stackoverflow.com/questions/34563451/set-mpnowplayinginfocenter-with-other-background-audio-playing
         //This isn't currently possible in iOS. Even just changing your category options to .MixWithOthers causes your nowPlayingInfo to be ignored.
-        do {
-            if #available(iOS 10.0, *) {
-                try AVAudioSession.sharedInstance().setCategory(.multiRoute, mode: .default, options: [])
-                try AVAudioSession.sharedInstance().setActive(true)
-                  UIApplication.shared.beginReceivingRemoteControlEvents()
-            } else {
-                try AVAudioSession.sharedInstance().setCategory(.multiRoute, options: [])
-                try AVAudioSession.sharedInstance().setActive(true)
-                  UIApplication.shared.beginReceivingRemoteControlEvents()
+     
+        if(isDefaultAudioConfigurationEnabled) {
+            do {
+                if #available(iOS 10.0, *) {
+                    try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
+                    try AVAudioSession.sharedInstance().setActive(true)
+                      UIApplication.shared.beginReceivingRemoteControlEvents()
+                } else {
+                    try AVAudioSession.sharedInstance().setCategory(.playback, options: [])
+                    try AVAudioSession.sharedInstance().setActive(true)
+                      UIApplication.shared.beginReceivingRemoteControlEvents()
+                }
+            } catch let error {
+                print(error)
             }
-        } catch let error {
-            print(error)
         }
+       
     }
     
     func deinitMediaPlayerNotifEvent() {
@@ -517,16 +522,21 @@ public class Player : NSObject, AVAudioPlayerDelegate {
             print("mode " + mode.rawValue)
             print("displayNotification " + displayNotification.description)
             print("url: " + url.absoluteString)
+          
             
-            /* set session category and mode with options */
-            if #available(iOS 10.0, *) {
-                try AVAudioSession.sharedInstance().setCategory(category, mode: .default, options: [])
-                try AVAudioSession.sharedInstance().setActive(true)
-            } else {
-                try AVAudioSession.sharedInstance().setCategory(category)
-                try AVAudioSession.sharedInstance().setActive(true)
-                
+            print("isDefaultAudioConfigurationEnabled - \(isDefaultAudioConfigurationEnabled)")
+            if(self.isDefaultAudioConfigurationEnabled) {
+                /* set session category and mode with options */
+                if #available(iOS 10.0, *) {
+                    try AVAudioSession.sharedInstance().setCategory(category, mode: .default, options: [])
+                    try AVAudioSession.sharedInstance().setActive(true)
+                } else {
+                    try AVAudioSession.sharedInstance().setCategory(category)
+                    try AVAudioSession.sharedInstance().setActive(true)
+                    
+                }
             }
+           
             #endif
             
             var item : SlowMoPlayerItem
@@ -567,8 +577,6 @@ public class Player : NSObject, AVAudioPlayerDelegate {
             // Watch notifications
             notifCenter.addObserver(self, selector: #selector(self.newErrorLogEntry), name: NSNotification.Name.AVPlayerItemNewErrorLogEntry, object: item)
             notifCenter.addObserver(self, selector: #selector(self.failedToPlayToEndTime), name: NSNotification.Name.AVPlayerItemFailedToPlayToEndTime, object: item)
-            
-            notifCenter.addObserver(self, selector: #selector(self.volumeChanged), name: NSNotification.Name(rawValue: "AVSystemController_SystemVolumeDidChangeNotification"), object: nil)
             
             self.setBuffering(true)
             
@@ -959,13 +967,6 @@ public class Player : NSObject, AVAudioPlayerDelegate {
             playing = false
             self.channel.invokeMethod(Music.METHOD_FINISHED, arguments: true)
             self._deinit()
-        }
-    }
-    
-    @objc func volumeChanged(notification: NSNotification){
-        let volume = notification.userInfo?["AVSystemController_AudioVolumeNotificationParameter"]
-        if let doubleVolume = volume as? Double {
-            self.setVolume(volume: doubleVolume)
         }
     }
     
@@ -1492,6 +1493,38 @@ class Music : NSObject, FlutterPlugin {
                         networkHeaders: networkHeaders,
                         result: result
                 )
+                
+            case "enableIOSDefaultAudioSessionConfiguration" :
+                guard let args = call.arguments as? NSDictionary else {
+                    result(FlutterError(
+                            code: "METHOD_CALL",
+                            message: call.method + " Arguments must be an NSDictionary",
+                            details: nil)
+                    )
+                    break
+                }
+                
+                guard let isEnabled = args["isEnabled"] as? Bool else {
+                    result(FlutterError(
+                            code: "METHOD_CALL",
+                            message: call.method + " Arguments[path] must be a Bool",
+                            details: nil)
+                    )
+                    break
+                }
+                
+                guard let id = args["id"] as? String else {
+                    result(FlutterError(
+                        code: "METHOD_CALL",
+                        message: call.method + " Arguments[id] must be a String",
+                        details: nil)
+                    )
+                    break
+                }
+
+                
+                self.getOrCreatePlayer(id: id).isDefaultAudioConfigurationEnabled = isEnabled
+                break
                 
             default:
                 result(FlutterMethodNotImplemented)

--- a/ios/Classes/Music.swift
+++ b/ios/Classes/Music.swift
@@ -523,7 +523,7 @@ public class Player : NSObject, AVAudioPlayerDelegate {
             print("url: " + url.absoluteString)
           
             
-            print("isDefaultAudioConfigurationEnabled - \(isDefaultAudioConfigurationEnabled)")
+            print("Music isDefaultAudioConfigurationEnabled - \(isDefaultAudioConfigurationEnabled)")
             if(self.isDefaultAudioConfigurationEnabled) {
                 /* set session category and mode with options */
                 if #available(iOS 10.0, *) {
@@ -1402,6 +1402,38 @@ class Music : NSObject, FlutterPlugin {
                 self.getOrCreatePlayer(id: id).onAudioUpdated(path: path, audioMetas: audioMetas)
                 result(true)
                 
+            case "enableIOSDefaultAudioSessionConfiguration" :
+                guard let args = call.arguments as? NSDictionary else {
+                    result(FlutterError(
+                            code: "METHOD_CALL",
+                            message: call.method + " Arguments must be an NSDictionary",
+                            details: nil)
+                    )
+                    break
+                }
+                
+                guard let isEnabled = args["isEnabled"] as? Bool else {
+                    result(FlutterError(
+                            code: "METHOD_CALL",
+                            message: call.method + " Arguments[path] must be a Bool",
+                            details: nil)
+                    )
+                    break
+                }
+                
+                guard let id = args["id"] as? String else {
+                    result(FlutterError(
+                            code: "METHOD_CALL",
+                            message: call.method + " Arguments[id] must be a String",
+                            details: nil)
+                    )
+                    break
+                }
+                
+                
+                self.getOrCreatePlayer(id: id).isDefaultAudioConfigurationEnabled = isEnabled
+                break
+                
             case "open" :
                 guard let args = call.arguments as? NSDictionary else {
                     result(FlutterError(
@@ -1492,39 +1524,7 @@ class Music : NSObject, FlutterPlugin {
                         networkHeaders: networkHeaders,
                         result: result
                 )
-                
-            case "enableIOSDefaultAudioSessionConfiguration" :
-                guard let args = call.arguments as? NSDictionary else {
-                    result(FlutterError(
-                            code: "METHOD_CALL",
-                            message: call.method + " Arguments must be an NSDictionary",
-                            details: nil)
-                    )
-                    break
-                }
-                
-                guard let isEnabled = args["isEnabled"] as? Bool else {
-                    result(FlutterError(
-                            code: "METHOD_CALL",
-                            message: call.method + " Arguments[path] must be a Bool",
-                            details: nil)
-                    )
-                    break
-                }
-                
-                guard let id = args["id"] as? String else {
-                    result(FlutterError(
-                        code: "METHOD_CALL",
-                        message: call.method + " Arguments[id] must be a String",
-                        details: nil)
-                    )
-                    break
-                }
 
-                
-                self.getOrCreatePlayer(id: id).isDefaultAudioConfigurationEnabled = isEnabled
-                break
-                
             default:
                 result(FlutterMethodNotImplemented)
                 break

--- a/ios/Classes/Music.swift
+++ b/ios/Classes/Music.swift
@@ -282,16 +282,15 @@ public class Player : NSObject, AVAudioPlayerDelegate {
                 if #available(iOS 10.0, *) {
                     try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
                     try AVAudioSession.sharedInstance().setActive(true)
-                      UIApplication.shared.beginReceivingRemoteControlEvents()
                 } else {
                     try AVAudioSession.sharedInstance().setCategory(.playback, options: [])
                     try AVAudioSession.sharedInstance().setActive(true)
-                      UIApplication.shared.beginReceivingRemoteControlEvents()
                 }
             } catch let error {
                 print(error)
             }
         }
+        UIApplication.shared.beginReceivingRemoteControlEvents()
        
     }
     

--- a/lib/src/assets_audio_player.dart
+++ b/lib/src/assets_audio_player.dart
@@ -38,6 +38,7 @@ const _DEFAULT_RESPECT_SILENT_MODE = false;
 const _DEFAULT_SHOW_NOTIFICATION = false;
 const _DEFAULT_PLAY_IN_BACKGROUND = PlayInBackground.enabled;
 const _DEFAULT_PLAYER = "DEFAULT_PLAYER";
+const _DEFAULT_IOS_AUDIO_SESSION_CONFIGURATIONS = true;
 const _DEFAULT_NETWORK_SETTINGS = NetworkSettings();
 
 const METHOD_POSITION = "player.position";
@@ -192,6 +193,18 @@ class AssetsAudioPlayer {
 
   final String id;
   final NetworkSettings networkSettings = _DEFAULT_NETWORK_SETTINGS;
+
+  // Setting the IOS AvAudioSession configurations (Like SetCategory , SetActive). By default it enabled.
+  // Call it before playing any song.
+  bool _enableIOSDefaultAudioSessionConfiguration = _DEFAULT_IOS_AUDIO_SESSION_CONFIGURATIONS;
+  set enableIOSDefaultAudioSessionConfiguration(bool newValue) {
+    if(!Platform.isIOS) {
+      return;
+    }
+    _enableIOSDefaultAudioSessionConfiguration = newValue;
+    /* await */ _sendChannel.invokeMethod(
+        'enableIOSDefaultAudioSessionConfiguration', {"id": this.id, "isEnabled": _enableIOSDefaultAudioSessionConfiguration});
+  }
 
   set cachePathProvider(AssetsAudioPlayerCache newValue) {
     if (newValue != null) {


### PR DESCRIPTION
- Setting back the category as Playback
- Removed the Volume change observer.
- Added the parameter-driven key to enable the default iOS configuration.